### PR TITLE
Provide default value for debug

### DIFF
--- a/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
+++ b/lib/src/main/java/com/ihsanbal/logging/LoggingInterceptor.java
@@ -124,7 +124,7 @@ public class LoggingInterceptor implements Interceptor {
     public static class Builder {
 
         private static String TAG = "LoggingI";
-        private boolean isDebug;
+        private boolean isDebug = true;
         private int type = Platform.INFO;
         private String requestTag;
         private String responseTag;


### PR DESCRIPTION
Provide default value for debug variable in debug or release mode.
I'm forced to add `.loggable(BuildConfig.DEBUG)` in order to print response. In my opinion, if i want to use this logger, i want to run by default.